### PR TITLE
Utilize Mutli-shot examples in MLLU and MLLU-Pro 

### DIFF
--- a/llm_eval_test/benchmarks/tasks/mmlu/mmlu.yaml
+++ b/llm_eval_test/benchmarks/tasks/mmlu/mmlu.yaml
@@ -1,3 +1,3 @@
 task: mmlu_all
 include: unitxt
-recipe: card=cards.mmlu.all,template=templates.qa.multiple_choice.with_topic.lm_eval_harness
+recipe: card=cards.mmlu.all,template=templates.qa.multiple_choice.with_topic.lm_eval_harness,num_demos=5,demos_pool_size=10

--- a/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_all.yaml
+++ b/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_all.yaml
@@ -1,3 +1,3 @@
 task: mmlu_pro_all
 include: unitxt
-recipe: card=cards.mmlu_pro.all,template=templates.qa.multiple_choice.with_topic.lm_eval_harness
+recipe: card=cards.mmlu_pro.all,template=templates.qa.multiple_choice.with_topic.lm_eval_harness,num_demos=1,demos_pool_size=4

--- a/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_biology.yaml
+++ b/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_biology.yaml
@@ -1,3 +1,3 @@
 task: mmlu_pro_biology
 include: unitxt
-recipe: card=cards.mmlu_pro.biology,template=templates.qa.multiple_choice.with_topic.lm_eval_harness
+recipe: card=cards.mmlu_pro.biology,template=templates.qa.multiple_choice.with_topic.lm_eval_harness,num_demos=1,demos_pool_size=4

--- a/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_business.yaml
+++ b/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_business.yaml
@@ -1,3 +1,3 @@
 task: mmlu_pro_business
 include: unitxt
-recipe: card=cards.mmlu_pro.business,template=templates.qa.multiple_choice.with_topic.lm_eval_harness
+recipe: card=cards.mmlu_pro.business,template=templates.qa.multiple_choice.with_topic.lm_eval_harness,num_demos=1,demos_pool_size=4

--- a/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_chemistry.yaml
+++ b/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_chemistry.yaml
@@ -1,3 +1,3 @@
 task: mmlu_pro_chemistry
 include: unitxt
-recipe: card=cards.mmlu_pro.chemistry,template=templates.qa.multiple_choice.with_topic.lm_eval_harness
+recipe: card=cards.mmlu_pro.chemistry,template=templates.qa.multiple_choice.with_topic.lm_eval_harness,num_demos=1,demos_pool_size=4

--- a/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_computer_science.yaml
+++ b/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_computer_science.yaml
@@ -1,3 +1,3 @@
 task: mmlu_pro_computer_science
 include: unitxt
-recipe: card=cards.mmlu_pro.computer_science,template=templates.qa.multiple_choice.with_topic.lm_eval_harness
+recipe: card=cards.mmlu_pro.computer_science,template=templates.qa.multiple_choice.with_topic.lm_eval_harness,num_demos=1,demos_pool_size=4

--- a/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_economics.yaml
+++ b/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_economics.yaml
@@ -1,3 +1,3 @@
 task: mmlu_pro_economics
 include: unitxt
-recipe: card=cards.mmlu_pro.economics,template=templates.qa.multiple_choice.with_topic.lm_eval_harness
+recipe: card=cards.mmlu_pro.economics,template=templates.qa.multiple_choice.with_topic.lm_eval_harness,num_demos=1,demos_pool_size=4

--- a/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_engineering.yaml
+++ b/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_engineering.yaml
@@ -1,3 +1,3 @@
 task: mmlu_pro_engineering
 include: unitxt
-recipe: card=cards.mmlu_pro.engineering,template=templates.qa.multiple_choice.with_topic.lm_eval_harness
+recipe: card=cards.mmlu_pro.engineering,template=templates.qa.multiple_choice.with_topic.lm_eval_harness,num_demos=1,demos_pool_size=4

--- a/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_health.yaml
+++ b/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_health.yaml
@@ -1,3 +1,3 @@
 task: mmlu_pro_health
 include: unitxt
-recipe: card=cards.mmlu_pro.health,template=templates.qa.multiple_choice.with_topic.lm_eval_harness
+recipe: card=cards.mmlu_pro.health,template=templates.qa.multiple_choice.with_topic.lm_eval_harness,num_demos=1,demos_pool_size=4

--- a/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_history.yaml
+++ b/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_history.yaml
@@ -1,3 +1,3 @@
 task: mmlu_pro_history
 include: unitxt
-recipe: card=cards.mmlu_pro.history,template=templates.qa.multiple_choice.with_topic.lm_eval_harness
+recipe: card=cards.mmlu_pro.history,template=templates.qa.multiple_choice.with_topic.lm_eval_harness,num_demos=1,demos_pool_size=4

--- a/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_law.yaml
+++ b/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_law.yaml
@@ -1,3 +1,3 @@
 task: mmlu_pro_law
 include: unitxt
-recipe: card=cards.mmlu_pro.law,template=templates.qa.multiple_choice.with_topic.lm_eval_harness
+recipe: card=cards.mmlu_pro.law,template=templates.qa.multiple_choice.with_topic.lm_eval_harness,num_demos=1,demos_pool_size=4

--- a/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_math.yaml
+++ b/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_math.yaml
@@ -1,3 +1,3 @@
 task: mmlu_pro_math
 include: unitxt
-recipe: card=cards.mmlu_pro.math,template=templates.qa.multiple_choice.with_topic.lm_eval_harness
+recipe: card=cards.mmlu_pro.math,template=templates.qa.multiple_choice.with_topic.lm_eval_harness,num_demos=1,demos_pool_size=4

--- a/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_other.yaml
+++ b/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_other.yaml
@@ -1,3 +1,3 @@
 task: mmlu_pro_other
 include: unitxt
-recipe: card=cards.mmlu_pro.other,template=templates.qa.multiple_choice.with_topic.lm_eval_harness
+recipe: card=cards.mmlu_pro.other,template=templates.qa.multiple_choice.with_topic.lm_eval_harness,num_demos=1,demos_pool_size=4,num_demos=1,demos_pool_size=4

--- a/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_philosophy.yaml
+++ b/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_philosophy.yaml
@@ -1,3 +1,3 @@
 task: mmlu_pro_philosophy
 include: unitxt
-recipe: card=cards.mmlu_pro.philosophy,template=templates.qa.multiple_choice.with_topic.lm_eval_harness
+recipe: card=cards.mmlu_pro.philosophy,template=templates.qa.multiple_choice.with_topic.lm_eval_harness,num_demos=1,demos_pool_size=4

--- a/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_physics.yaml
+++ b/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_physics.yaml
@@ -1,3 +1,3 @@
 task: mmlu_pro_physics
 include: unitxt
-recipe: card=cards.mmlu_pro.physics,template=templates.qa.multiple_choice.with_topic.lm_eval_harness
+recipe: card=cards.mmlu_pro.physics,template=templates.qa.multiple_choice.with_topic.lm_eval_harness,num_demos=1,demos_pool_size=4

--- a/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_psychology.yaml
+++ b/llm_eval_test/benchmarks/tasks/mmlu_pro/mmlu_pro_psychology.yaml
@@ -1,3 +1,3 @@
 task: mmlu_pro_psychology
 include: unitxt
-recipe: card=cards.mmlu_pro.psychology,template=templates.qa.multiple_choice.with_topic.lm_eval_harness
+recipe: card=cards.mmlu_pro.psychology,template=templates.qa.multiple_choice.with_topic.lm_eval_harness,num_demos=1,demos_pool_size=4


### PR DESCRIPTION
The MMLU and MLLU-Pro benchmarks are currently 0-shot which does not align with the standard configuration used by plain lm-eval-harness.