### PR TITLE
Better output options

### DIFF
--- a/llm_eval_test/lm_eval_wrapper.py
+++ b/llm_eval_test/lm_eval_wrapper.py
@@ -35,7 +35,7 @@ class LMEvalWrapper(object):
             model_args=model_args_str,
             tasks=tasks,
             #num_fewshot=self.few_shots,
-            batch_size=kwargs['batch_size'],
+            batch_size=kwargs['batch'],
             task_manager=tm,
             verbosity=logging.getLevelName(kwargs['loglevel'])
         )

--- a/llm_eval_test/lm_eval_wrapper.py
+++ b/llm_eval_test/lm_eval_wrapper.py
@@ -8,6 +8,8 @@ from lm_eval.evaluator import simple_evaluate
 from lm_eval.tasks import TaskManager  # type: ignore
 from lm_eval.utils import handle_non_serializable, make_table
 
+from llm_eval_test.parser import OutputFormat
+
 logger = logging.getLogger("llm-eval-test")
 
 class LMEvalWrapper(object):
@@ -44,8 +46,15 @@ class LMEvalWrapper(object):
             if kwargs.get('output'):
                 # Write results to outfile
                 logger.info(f"Writing results to {kwargs['output'].name}")
+
+                if kwargs['format'] == OutputFormat.summary:
+                    results_out = results.copy()
+                    results_out.pop("samples")
+                else: # kwargs['format'] == 'full'
+                    results_out = results
+
                 output = json.dumps(
-                    results, indent=2, default=handle_non_serializable, ensure_ascii=False
+                    results_out, indent=2, default=handle_non_serializable, ensure_ascii=False
                 )
                 kwargs['output'].write(output)
 

--- a/llm_eval_test/parser.py
+++ b/llm_eval_test/parser.py
@@ -4,6 +4,7 @@ import enum
 import os
 import logging
 import argparse
+import datetime
 
 
 class OutputFormat(enum.Enum):
@@ -38,10 +39,6 @@ def setup_parser(local_dir: str, work_dir: str) -> argparse.ArgumentParser:
     parser_base.add_argument('--tasks-path', type=dir_path,
                         default=f"{local_dir}/benchmarks/tasks",
                              help="lm-eval tasks directory", metavar='PATH')
-    parser_base.add_argument('--format', type=OutputFormat,
-                             choices=list(OutputFormat),
-                             default=OutputFormat.default,
-                             help="format of output file")
     log_group = parser_base.add_mutually_exclusive_group()
     log_group.add_argument('-v', '--verbose', default=Defaults.log_level,
                            action="store_const", dest="loglevel", const=logging.DEBUG,
@@ -79,8 +76,17 @@ def setup_parser(local_dir: str, work_dir: str) -> argparse.ArgumentParser:
                             help="per-request batch size", metavar='INT')
     parser_run.add_argument('-r', '--retry', default=Defaults.retry_count, type=int,
                             help="max number of times to retry a single request", metavar='INT')
-    parser_run.add_argument('-o', '--output', type=argparse.FileType('w'),
-                            help="results output file")
+    now_time = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H-%M-%S.%fZ")
+    output_group = parser_run.add_mutually_exclusive_group()
+    output_group.add_argument('-o', '--output', type=argparse.FileType('w'),
+                              default=f"{work_dir}/{now_time}.json",
+                              help="results output file")
+    output_group.add_argument('--no-output',
+                              action="store_const", dest="output", const=None,
+                              help="disable results output file")
+    parser_run.add_argument('--format', type=OutputFormat, default=OutputFormat.default,
+                              choices=list(OutputFormat),
+                              help="format of output file")
 
     parser_list = subparsers.add_parser(
         'list',

--- a/llm_eval_test/parser.py
+++ b/llm_eval_test/parser.py
@@ -5,6 +5,13 @@ import logging
 import argparse
 
 
+class Defaults(object):
+    """Default values for arguments."""
+    batch_size:  int = 32
+    retry_count: int = 5
+    log_level:   int = logging.INFO
+
+
 def setup_parser(local_dir: str, work_dir: str) -> argparse.ArgumentParser:
     def dir_path(path: str) -> str:
         ''' Typecheck for directory '''
@@ -14,14 +21,14 @@ def setup_parser(local_dir: str, work_dir: str) -> argparse.ArgumentParser:
             raise NotADirectoryError(path)
 
     parser_base = argparse.ArgumentParser(add_help=False)
-    parser_base.add_argument('--catalog_path', type=dir_path,
+    parser_base.add_argument('--catalog-path', type=dir_path,
                         default=f"{local_dir}/benchmarks/catalog",
                              help="unitxt catalog directory", metavar='PATH')
-    parser_base.add_argument('--tasks_path', type=dir_path,
+    parser_base.add_argument('--tasks-path', type=dir_path,
                         default=f"{local_dir}/benchmarks/tasks",
                              help="lm-eval tasks directory", metavar='PATH')
     log_group = parser_base.add_mutually_exclusive_group()
-    log_group.add_argument('-v', '--verbose', default=logging.INFO,
+    log_group.add_argument('-v', '--verbose', default=Defaults.log_level,
                            action="store_const", dest="loglevel", const=logging.DEBUG,
                            help="set loglevel to DEBUG")
     log_group.add_argument('-q', '--quiet',
@@ -53,10 +60,10 @@ def setup_parser(local_dir: str, work_dir: str) -> argparse.ArgumentParser:
     required.add_argument('-d', '--datasets', type=dir_path, required=True,
                           default=f"{work_dir}/datasets",
                           help="path to dataset storage", metavar='PATH')
-    parser_run.add_argument('-b', '--batch_size', default=64, type=int,
+    parser_run.add_argument('-b', '--batch', default=Defaults.batch_size, type=int,
                             help="per-request batch size", metavar='INT')
-    parser_run.add_argument('-r', '--retry', default=3, type=int,
-                            help="Max number of times to retry a single request", metavar='INT')
+    parser_run.add_argument('-r', '--retry', default=Defaults.retry_count, type=int,
+                            help="max number of times to retry a single request", metavar='INT')
     parser_run.add_argument('-o', '--output', type=argparse.FileType('w'),
                             help="results output file")
 

--- a/llm_eval_test/parser.py
+++ b/llm_eval_test/parser.py
@@ -1,8 +1,19 @@
 
 
+import enum
 import os
 import logging
 import argparse
+
+
+class OutputFormat(enum.Enum):
+    """Log file output format"""
+    full    = 'full'
+    summary = 'summary'
+    default = summary
+
+    def __str__(self):
+        return str(self.value)
 
 
 class Defaults(object):
@@ -27,6 +38,10 @@ def setup_parser(local_dir: str, work_dir: str) -> argparse.ArgumentParser:
     parser_base.add_argument('--tasks-path', type=dir_path,
                         default=f"{local_dir}/benchmarks/tasks",
                              help="lm-eval tasks directory", metavar='PATH')
+    parser_base.add_argument('--format', type=OutputFormat,
+                             choices=list(OutputFormat),
+                             default=OutputFormat.default,
+                             help="format of output file")
     log_group = parser_base.add_mutually_exclusive_group()
     log_group.add_argument('-v', '--verbose', default=Defaults.log_level,
                            action="store_const", dest="loglevel", const=logging.DEBUG,


### PR DESCRIPTION
* Re-enables JSON output by default. The filename is now an ISO timestamp rather than `output.json`.
* Adds a `--no-output` argument to disable JSON output.
* Adds a `--format` argument for specifying whether to output the full dataset of results or just the summary fields. Defaults to `summary`.
* Renames argument: `--batch_size` -> `--batch`
* Renames argument: `--tasks_path` -> `--tasks-path`
* Renames argument: `--catalog_path` -> `--catalog-path`
* Changes default batch size: `64` -> `32`
* Changes default retry count: `64` -> `5`