### PR TITLE
Fixed readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,21 +96,17 @@ required:
 ### Example: MMLU-Pro Benchmark
 
 ``` sh
-# Create dataset storage
-DATASETS_DIR=$(pwd)/datasets
-mkdir $DATASETS_DIR
-
-# Download the MMLU-Pro dataset
-DATASET=TIGER-Lab/MMLU-Pro
-
-# Use your preferred method of downloading the dataset to $DATASETS_DIR/$DATASET
-# to use the huggingface-cli:
-pip install huggingface_hub[cli]
-huggingface-cli download $DATASET --repo-type dataset --local-dir $DATASETS_DIR/$DATASET
 
 # Run the benchmark
 ENDPOINT=http://127.0.0.1:8080/v1/completions # An OpenAI API-compatable completions endpoint
 MODEL_NAME=meta-llama/Llama-3.1-8B # Name of the model hosted on the inference server
+TOKENIZER=ibm-granite/granite-3.1-8b-instruct
 llm-eval-test run --endpoint $ENDPOINT --model $MODEL_NAME --datasets $DATASETS_DIR --tasks mmlu_pro
+
+Examples:
+llm-eval-test run -H  ENDPOINT --model /mnt/models/ --tokenizer TOKENIZER --datasets ./datasets --tasks arc_challenge; 
+llm-eval-test run -H  ENDPOINT --model /mnt/models/ --tokenizer TOKENIZER --datasets ./datasets --tasks arc_challenge,gsm8k,arc_challenge,hellaswag,mmlu_pro,truthfulqa,winogrande
+llm-eval-test run -H  ENDPOINT --model /mnt/models/ --tokenizer TOKENIZER --datasets ./datasets --tasks leaderboard
+
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ llm-eval-test run --help
 ## Download Usage
 
 ``` sh
-# Create dataset storage
+
+# Create dataset directory
 DATASETS_DIR=$(pwd)/datasets
 mkdir $DATASETS_DIR
 
@@ -56,9 +57,9 @@ options:
                         Force download datasets even it already exist (default: False)
 
 
-llm-eval-test download arc_challenge,GSM8K,HellaSwag
-llm-eval-test download leaderboard
-llm-eval-test download arc_challenge,GSM8K,HellaSwag -f (to overwrite the previously downloaded datasets)
+llm-eval-test download --tasks arc_challenge,GSM8K,HellaSwag
+llm-eval-test download --tasks leaderboard
+llm-eval-test download --tasks arc_challenge,GSM8K,HellaSwag -f (to overwrite the previously downloaded datasets)
 ```
 
 ## Run Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "llm-eval-test"
 version = "0.2.1"
-description = ""
+description = "LLM Evaluation Test Tool"
 authors = [
     {name = "Samuel Monson", email = "smonson@redhat.com"},
 ]
@@ -17,6 +17,13 @@ readme = "README.md"
 leaderboard = [
     "lm-eval[ifeval,math,sentencepiece]>=0.4.8",
 ]
+
+[tool.pdm]
+package-dir = "src"
+package-type = "library"
+
+[tool.pdm.build]
+includes = ["src/llm_eval_test"]
 
 # Use cpu pytorch to avoid downloading cuda
 [[tool.pdm.source]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,6 @@ leaderboard = [
     "lm-eval[ifeval,math,sentencepiece]>=0.4.8",
 ]
 
-[tool.pdm]
-package-dir = "src"
-package-type = "library"
-
-[tool.pdm.build]
-includes = ["src/llm_eval_test"]
-
 # Use cpu pytorch to avoid downloading cuda
 [[tool.pdm.source]]
 name = "torch-cpu"


### PR DESCRIPTION
The pyproject.toml doesn’t explicitly tell the build system  to include src/llm_eval_test as the package, relying on PDM defaults that pip might not honor.

`
>llm-eval-test
Traceback (most recent call last):
  File "/root/python3_llm_eval/bin/llm-eval-test", line 5, in <module>
    from llm_eval_test.__main__ import eval_cli
ModuleNotFoundError: No module named 'llm_eval_test'
`