### PR TITLE
Add a --chat-template argument to enable the tokenizer chat template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,31 +65,39 @@ llm-eval-test download --tasks arc_challenge,GSM8K,HellaSwag -f (to overwrite th
 ## Run Usage
 
 ```
-usage: llm-eval-test run [-h] [--catalog_path PATH] [--tasks_path PATH] [-v | -q]
--H ENDPOINT -m MODEL -t TASKS -d PATH [-b INT] [-o OUTPUT]
+usage: llm-eval-test run [-h] [--catalog-path PATH] [--tasks-path PATH] [--offline | --no-offline] [-v | -q] -H ENDPOINT -m MODEL -t TASKS -d PATH [-T TOKENIZER] [-b INT] [-r INT] [-o OUTPUT | --no-output] [--format {full,summary}] [--chat-template | --no-chat-template]
 
 Run tasks
 
 options:
   -h, --help            show this help message and exit
-  --catalog_path PATH   unitxt catalog directory
-  --tasks_path PATH     lm-eval tasks directory
+  --catalog-path PATH   unitxt catalog directory
+  --tasks-path PATH     lm-eval tasks directory
+  --offline, --no-offline
+                        Disable/enable updating datasets from the internet
   -v, --verbose         set loglevel to DEBUG
   -q, --quiet           set loglevel to ERROR
-  -b INT, --batch_size INT
-                        per-request batch size
-  -o OUTPUT, --output OUTPUT
-                        results output file
+  -T, --tokenizer TOKENIZER
+                        path or huggingface tokenizer name, if none uses model name (default: None)
+  -b, --batch INT       per-request batch size
+  -r, --retry INT       max number of times to retry a single request
+  -o, --output OUTPUT   results output file
+  --no-output           disable results output file
+  --format {full,summary}
+                        format of output file
 
 required:
-  -H ENDPOINT, --endpoint ENDPOINT
+  -H, --endpoint ENDPOINT
                         OpenAI API-compatible endpoint
-  -m MODEL, --model MODEL
-                        name of the model under test
-  -t TASKS, --tasks TASKS
-                        comma separated list of tasks
-  -d PATH, --datasets PATH
-                        path to dataset storage
+  -m, --model MODEL     name of the model under test
+  -t, --tasks TASKS     comma separated list of tasks
+  -d, --datasets PATH   path to dataset storage
+
+prompt parameters:
+  these modify the prompt sent to the server and thus will affect the results
+
+  --chat-template, --no-chat-template
+                        use chat template for requests
 
 ```
 

--- a/src/llm_eval_test/__main__.py
+++ b/src/llm_eval_test/__main__.py
@@ -77,7 +77,7 @@ def eval_cli():
                 try:
                     os.symlink(f"{args.datasets}/{dataset}", f"{tmpdir}/{dataset}")
                 except FileExistsError:
-                    logger.warn(f"Dataset '{dataset}' conflicts with existing wrapper, skipping")
+                    logger.warning(f"Dataset '{dataset}' conflicts with existing wrapper, skipping")
 
             # Call wrapped lm-eval
             args.tasks = args.tasks.split(",")

--- a/src/llm_eval_test/lm_eval_wrapper.py
+++ b/src/llm_eval_test/lm_eval_wrapper.py
@@ -21,7 +21,7 @@ class LMEvalWrapper:
             "model": model,
             "tokenizer": tokenizer,
             "base_url": endpoint,
-            "num_concurent": 1,
+            "num_concurrent": 1,
             "max_retries": kwargs["retry"],
             "tokenizer_backend": "huggingface",
             "verify_certificate": False,
@@ -36,8 +36,8 @@ class LMEvalWrapper:
         results = simple_evaluate(
             model="local-completions",
             model_args=model_args_str,
+            apply_chat_template=kwargs.get("chat_template", False),
             tasks=tasks,
-            # num_fewshot=self.few_shots,
             batch_size=kwargs["batch"],
             task_manager=tm,
         )

--- a/src/llm_eval_test/lm_eval_wrapper.py
+++ b/src/llm_eval_test/lm_eval_wrapper.py
@@ -53,6 +53,7 @@ class LMEvalWrapper:
                 else:  # kwargs['format'] == 'full'
                     results_out = results
 
+                results_out["let_config"] = kwargs
                 output = json.dumps(results_out, indent=2, default=handle_non_serializable, ensure_ascii=False)
                 kwargs["output"].write(output)
 

--- a/src/llm_eval_test/lm_eval_wrapper.py
+++ b/src/llm_eval_test/lm_eval_wrapper.py
@@ -37,6 +37,7 @@ class LMEvalWrapper:
             model="local-completions",
             model_args=model_args_str,
             apply_chat_template=kwargs.get("chat_template", False),
+            fewshot_as_multiturn=kwargs.get("chat_template", False),
             tasks=tasks,
             batch_size=kwargs["batch"],
             task_manager=tm,

--- a/src/llm_eval_test/parser.py
+++ b/src/llm_eval_test/parser.py
@@ -98,13 +98,6 @@ def setup_parser(local_dir: str, work_dir: str) -> argparse.ArgumentParser:
     )
     parser_run.add_argument("-T", "--tokenizer", help="path or huggingface tokenizer name, if none uses model name")
     parser_run.add_argument(
-        "--chat-template",
-        action=argparse.BooleanOptionalAction,
-        type=bool,
-        default=False,
-        help="use chat template for requests",
-    )
-    parser_run.add_argument(
         "-b", "--batch", default=Defaults.batch_size, type=int, help="per-request batch size", metavar="INT"
     )
     parser_run.add_argument(
@@ -129,6 +122,17 @@ def setup_parser(local_dir: str, work_dir: str) -> argparse.ArgumentParser:
         default=OutputFormat.default,
         choices=list(OutputFormat),
         help="format of output file",
+    )
+    prompt_args = parser_run.add_argument_group(
+        title="prompt parameters",
+        description="these modify the prompt sent to the server and thus will affect the results",
+    )
+    prompt_args.add_argument(
+        "--chat-template",
+        action=argparse.BooleanOptionalAction,
+        type=bool,
+        default=False,
+        help="use chat template for requests",
     )
 
     parser_list = subparsers.add_parser(  # noqa: F841

--- a/src/llm_eval_test/parser.py
+++ b/src/llm_eval_test/parser.py
@@ -96,7 +96,14 @@ def setup_parser(local_dir: str, work_dir: str) -> argparse.ArgumentParser:
         help="path to dataset storage",
         metavar="PATH",
     )
-    parser_run.add_argument("--tokenizer", help="path or huggingface tokenizer name, if none uses model name")
+    parser_run.add_argument("-T", "--tokenizer", help="path or huggingface tokenizer name, if none uses model name")
+    parser_run.add_argument(
+        "--chat-template",
+        action=argparse.BooleanOptionalAction,
+        type=bool,
+        default=False,
+        help="use chat template for requests",
+    )
     parser_run.add_argument(
         "-b", "--batch", default=Defaults.batch_size, type=int, help="per-request batch size", metavar="INT"
     )


### PR DESCRIPTION
Replacement for #30. Since lm-eval has access to the tokenizer it can apply the chat template client-side, which means we do not need to support `/v1/chat/completions`.

Fixes #28 