### PR TITLE
Use lm-eval 0.4.11 to solve issue with transformers v5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "Samuel Monson", email = "smonson@redhat.com"},
 ]
 dependencies = [
-    "lm-eval[api]==0.4.9.2",
+    "lm-eval[api]==0.4.11",
     "unitxt==1.22.0",
     "torch>=1.8",
 ]
@@ -15,7 +15,7 @@ readme = "README.md"
 
 [project.optional-dependencies]
 leaderboard = [
-    "lm-eval[ifeval,math,sentencepiece]>=0.4.8",
+    "lm-eval[ifeval,math,sentencepiece]>=0.4.11",
 ]
 
 # Use cpu pytorch to avoid downloading cuda


### PR DESCRIPTION
Try bumping up lm-eval version to 0.4.11 to solve following error with transformers v5:

```
.venv/lib64/python3.12/site-packages/lm_eval/models/hf_vlms.py:37: in HFMultimodalLM
    AUTO_MODEL_CLASS = transformers.AutoModelForVision2Seq
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module transformers has no attribute AutoModelForVision2Seq
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->